### PR TITLE
Changed the default_title to B&W Filter to keep the name smaller.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   },
   "browser_action": {
     "browser_style": true,
-    "default_title": "Apply black and white filter",
+    "default_title": "B&W filter",
     "default_icon": {
       "19": "icons/icon-19.png",
       "38": "icons/icon-38.png"
@@ -38,7 +38,7 @@
     "storage",
     "activeTab"
   ],
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "Maxim Perry",
   "web_accessible_resources": [
     "icons/*.png",


### PR DESCRIPTION
I just changed the name from "Apply black and white filter" to "B&W Filter" because on my old-school Firefox, the long name takes up a lot of real-estate on my old-school add-on bar.

I guess this won't matter if I ever update to something more recent.